### PR TITLE
Patch/fix css injection

### DIFF
--- a/gulpfile-admin.js
+++ b/gulpfile-admin.js
@@ -1,6 +1,7 @@
 var gulp = require( "gulp" );
+var del = require( "del" );
 var $ = require( "gulp-load-plugins" )();
-var browserSync = require( "browser-sync" );
+var browserSync = require( "browser-sync" ).create();
 
 var vendorStyles = [
 	"bower_components/jquery-file-upload/css/jquery.fileupload.css",
@@ -17,6 +18,7 @@ var vendorScripts = [
 	"bower_components/bootstrap/dist/js/bootstrap.js",
 	"bower_components/atk14js/src/atk14.js"
 ];
+
 var applicationScripts = [
 	"public/admin/scripts/application.js"
 ];
@@ -31,7 +33,7 @@ gulp.task( "styles-admin", function() {
 		.pipe( $.rename( { suffix: ".min" } ) )
 		.pipe( $.sourcemaps.write( "." ) )
 		.pipe( gulp.dest( "public/admin/dist/styles" ) )
-		.pipe( browserSync.stream() );
+		.pipe( browserSync.stream( { match: "**/*.css" } ) );
 } );
 
 gulp.task( "styles-vendor-admin", function() {
@@ -43,7 +45,7 @@ gulp.task( "styles-vendor-admin", function() {
 		.pipe( $.rename( { suffix: ".min" } ) )
 		.pipe( $.sourcemaps.write( "." ) )
 		.pipe( gulp.dest( "public/admin/dist/styles" ) )
-		.pipe( browserSync.stream() );
+		.pipe( browserSync.stream( { match: "**/*.css" } ) );
 } );
 
 // JS
@@ -95,7 +97,9 @@ gulp.task( "copy-admin", function() {
 } );
 
 // Clean
-gulp.task( "clean-admin", require( "del" ).bind( null, [ "public/admin/dist" ] ) );
+gulp.task( "clean-admin", function() {
+	del( "admin/dist" );
+} );
 
 // Server
 gulp.task( "serve-admin", [ "styles-admin", "styles-vendor-admin" ], function() {
@@ -103,13 +107,17 @@ gulp.task( "serve-admin", [ "styles-admin", "styles-vendor-admin" ], function() 
 		proxy: "atk14skelet.localhost/admin/"
 	} );
 
+	// If these files change = reload browser
 	gulp.watch( [
 		"app/**/*.tpl",
-		"public/admin/scripts/**/*.js",
 		"public/admin/images/**/*"
 	] ).on( "change", browserSync.reload );
 
-	gulp.watch( "public/admin/styles/**/*.less", [ "styles" ] );
+	// If javascript files change = run 'scripts' task, then reload browser
+	gulp.watch( "public/admin/scripts/**/*.js", [ "scripts" ] ).on( "change", browserSync.reload );
+
+	// If styles files change = run 'styles' task with style injection
+	gulp.watch( "public/admin/styles/**/*.less", [ "styles-admin" ] );
 } );
 
 // Build

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ gulp.task( "styles", function() {
 		.pipe( $.rename( { suffix: ".min" } ) )
 		.pipe( $.sourcemaps.write( "." ) )
 		.pipe( gulp.dest( "public/dist/styles" ) )
-		.pipe( browserSync.stream() );
+		.pipe( browserSync.stream( { match: "**/*.css" } ) );
 } );
 
 gulp.task( "styles-vendor", function() {
@@ -38,7 +38,7 @@ gulp.task( "styles-vendor", function() {
 		.pipe( $.rename( { suffix: ".min" } ) )
 		.pipe( $.sourcemaps.write( "." ) )
 		.pipe( gulp.dest( "public/dist/styles" ) )
-		.pipe( browserSync.stream() );
+		.pipe( browserSync.stream( { match: "**/*.css" } ) );
 } );
 
 // JS
@@ -58,7 +58,7 @@ gulp.task( "scripts", function() {
 		.pipe( $.rename( { suffix: ".min" } ) )
 		.pipe( $.sourcemaps.write( "." ) )
 		.pipe( gulp.dest( "public/dist/scripts" ) )
-		.pipe( browserSync.stream() );
+		.pipe( browserSync.stream( { match: "**/*.css" } ) );
 } );
 
 // Lint
@@ -99,12 +99,16 @@ gulp.task( "serve", [ "styles" ], function() {
 		proxy: "atk14skelet.localhost"
 	} );
 
+	// If these files change = reload browser
 	gulp.watch( [
 		"app/**/*.tpl",
-		"public/scripts/**/*.js",
 		"public/images/**/*"
 	] ).on( "change", browserSync.reload );
 
+	// If javascript files change = run 'scripts' task, then reload browser
+	gulp.watch( "public/scripts/**/*.js", [ "scripts" ] ).on( "change", browserSync.reload );
+
+	// If styles files change = run 'styles' task with style injection
 	gulp.watch( "public/styles/**/*.less", [ "styles" ] );
 } );
 

--- a/package.json
+++ b/package.json
@@ -29,21 +29,21 @@
     "url": "https://github.com/atk14/Atk14Skelet/issues"
   },
   "devDependencies": {
-    "browser-sync": "^2.11.2",
+    "browser-sync": "^2.18.8",
     "del": "^2.0.2",
     "gulp": "^3.9.1",
-    "gulp-autoprefixer": "^3.0.1",
-    "gulp-clean-css": "^2.0.5",
+    "gulp-autoprefixer": "^3.1.1",
+    "gulp-clean-css": "^3.0.3",
     "gulp-concat": "^2.6.0",
-    "gulp-concat-css": "^2.2.0",
+    "gulp-concat-css": "^2.3.0",
     "gulp-debug": "^2.1.0",
     "gulp-jscs": "^2.0.0",
     "gulp-jshint": "^1.11.2",
-    "gulp-less": "^3.0.5",
-    "gulp-load-plugins": "^0.10.0",
+    "gulp-less": "^3.3.0",
+    "gulp-load-plugins": "^1.5.0",
     "gulp-rename": "^1.2.2",
     "gulp-size": "^2.1.0",
-    "gulp-sourcemaps": "^1.5.2",
+    "gulp-sourcemaps": "^2.4.0",
     "gulp-uglify": "^1.5.3",
     "jshint-stylish": "^2.0.1"
   }


### PR DESCRIPTION
1. Oprava generovani sourcemap a injectovaní stylů. Uprava jak v gulp, tak gulp-admin  
2. Drobná konsolidace _gulpfile-admin_ kodu, aby byl mel stejny zaklad jako _gulpfile_ frontendu.
3. Aktualizace vybranych node_modules na posledni stable verze. (otestováno)

Kombinace generovani sourcemap a injectovani zmen v CSS nefungovala dohromady.
Nove vznikly soubor sourcemapy narusil stream a browsersync reloadnul stranku (nedoslo k injectu).
Po uprave kdy zachytava jen zmeny v CSS filech viz ` browserSync.stream( { match: "**/*.css" } ` uz funguje oboji dohromady.