### PR TITLE
Migrate JSCS & JSHint to ESLint for ADMIN also.

### DIFF
--- a/gulpfile-admin.js
+++ b/gulpfile-admin.js
@@ -76,14 +76,9 @@ gulp.task( "scripts-admin", function() {
 // Lint
 gulp.task( "lint-admin", function() {
 	return gulp.src( [ "public/admin/scripts/**/*.js", "gulpfile-admin.js" ] )
-		.pipe( $.jshint() )
-		.pipe( $.jshint.reporter( "jshint-stylish" ) );
-} );
-
-// Code style
-gulp.task( "jscs-admin", function() {
-	return gulp.src( [ "public/admin/scripts/**/*.js", "gulpfile-admin.js" ] )
-		.pipe( $.jscs() );
+		.pipe( $.eslint() )
+		.pipe( $.eslint.format() )
+		.pipe( $.eslint.failAfterError() );
 } );
 
 // Copy
@@ -132,7 +127,6 @@ gulp.task( "serve-admin", [ "styles-admin", "styles-vendor-admin" ], function() 
 // Build
 var buildTasks = [
 	"lint-admin",
-	"jscs-admin",
 	"styles-admin",
 	"styles-vendor-admin",
 	"scripts-admin",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,6 @@ gulp.task( "scripts", function() {
 // Lint & Code style
 gulp.task( "lint", function() {
 	return gulp.src( [ "public/scripts/**/*.js", "gulpfile.js" ] )
-		//.pipe( $.jshint() )
 		.pipe( $.eslint() )
 		.pipe( $.eslint.format() )
 		.pipe( $.eslint.failAfterError() );

--- a/public/admin/scripts/application.js
+++ b/public/admin/scripts/application.js
@@ -1,6 +1,8 @@
 /* global window */
 ( function( window, $, undefined ) {
 	var document = window.document,
+		ace = window.ace,
+		markdown = window.markdown,
 
 	ADMIN = {
 


### PR DESCRIPTION
Added migration for gulp-admin.